### PR TITLE
Fixed errors when restarting WebApp in Docker

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -349,6 +349,8 @@ db {
   #default.logSql=true
 }
 
+pidfile.path = "/dev/null"
+
 app.portWebapp = 8085
 
 webapi.port = 8080


### PR DESCRIPTION
**Reason for this PR**
When a docker image is built from the WebApps ```build.sbt```, and containers are being deployed, these containers cannot be restarted. Once stopped and started again (or after calling ```docker restart```), the container logs will show the message
```
This application is already running (Or delete /usr/share/odin/RUNNING_PID file).
```
and the container will exit immediately.

**Solution**
Based on [this](https://github.com/sbt/sbt-native-packager/issues/377#issuecomment-252026579) comment, i have change the configuration setting for the PID file. This fixed the problem, meaning i was able to stop, start and restart WebApp containers.