### PR TITLE
Adapt WebApp to latest changes of the registry interface

### DIFF
--- a/app/utils/Configuration.scala
+++ b/app/utils/Configuration.scala
@@ -17,7 +17,7 @@ package utils
 
 import com.typesafe.config.ConfigFactory
 import utils.instancemanagement.InstanceEnums.{ComponentType, InstanceState}
-import utils.instancemanagement.{Instance, InstanceRegistry}
+import utils.instancemanagement.{Instance, InstanceLink, InstanceRegistry}
 
 import scala.util.{Failure, Success, Try}
 
@@ -40,7 +40,9 @@ class Configuration(val bindPort: Int = ConfigFactory.load().getInt("app.portWeb
       ComponentType.WebApi,
       None,
       InstanceState.Running,
-      List.empty[String]
+      List.empty[String],
+      List.empty[InstanceLink],
+      List.empty[InstanceLink]
     )
 
   }

--- a/app/utils/instancemanagement/Instance.scala
+++ b/app/utils/instancemanagement/Instance.scala
@@ -16,63 +16,111 @@
 package utils.instancemanagement
 
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
+import utils.instancemanagement.InstanceEnums.{ComponentType, InstanceState}
 import spray.json.{DefaultJsonProtocol, DeserializationException, JsString, JsValue, JsonFormat}
 
-trait JsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
+/**
+  * Trait defining the implicit JSON formats needed to work with Instances
+  */
+trait InstanceJsonSupport extends SprayJsonSupport with DefaultJsonProtocol with InstanceLinkJsonSupport {
 
-  implicit val componentTypeFormat : JsonFormat[InstanceEnums.ComponentType] = new JsonFormat[InstanceEnums.ComponentType] {
+  //Custom JSON format for an ComponentType
+  implicit val componentTypeFormat : JsonFormat[ComponentType] = new JsonFormat[ComponentType] {
 
-    def write(compType : InstanceEnums.ComponentType) = JsString(compType.toString)
+    /**
+      * Custom write method for serializing an ComponentType
+      * @param compType The ComponentType to serialize
+      * @return JsString containing the serialized value
+      */
+    def write(compType : ComponentType) = JsString(compType.toString)
 
-    def read(value: JsValue) : InstanceEnums.ComponentType = value match {
+    /**
+      * Custom read method for deserialization of an ComponentType
+      * @param value JsValue to deserialize (must be a JsString)
+      * @return ComponentType that has been read
+      * @throws DeserializationException Exception thrown when JsValue is in incorrect format
+      */
+    def read(value: JsValue) : ComponentType = value match {
       case JsString(s) => s match {
-        case "Crawler" => InstanceEnums.ComponentType.Crawler
-        case "WebApi" => InstanceEnums.ComponentType.WebApi
-        case "WebApp" => InstanceEnums.ComponentType.WebApp
-        case "DelphiManagement" => InstanceEnums.ComponentType.DelphiManagement
-        case "ElasticSearch" => InstanceEnums.ComponentType.ElasticSearch
+        case "Crawler" => ComponentType.Crawler
+        case "WebApi" => ComponentType.WebApi
+        case "WebApp" => ComponentType.WebApp
+        case "DelphiManagement" => ComponentType.DelphiManagement
+        case "ElasticSearch" => ComponentType.ElasticSearch
         case x => throw DeserializationException(s"Unexpected string value $x for component type.")
       }
-      case y => throw DeserializationException(s"Unexpected type $y while deserializing component type.")
+      case y => throw DeserializationException(s"Unexpected type $y during deserialization component type.")
     }
   }
 
-  implicit val stateFormat  : JsonFormat[InstanceEnums.State] = new JsonFormat[InstanceEnums.State] {
+  //Custom JSON format for an InstanceState
+  implicit val stateFormat  : JsonFormat[InstanceState] = new JsonFormat[InstanceState] {
 
-    def write(compType : InstanceEnums.State) = JsString(compType.toString)
+    /**
+      * Custom write method for serializing an InstanceState
+      * @param state The InstanceState to serialize
+      * @return JsString containing the serialized value
+      */
+    def write(state : InstanceState) = JsString(state.toString)
 
-    def read(value: JsValue) : InstanceEnums.State = value match {
+    /**
+      * Custom read method for deserialization of an InstanceState
+      * @param value JsValue to deserialize (must be a JsString)
+      * @return InstanceState that has been read
+      * @throws DeserializationException Exception thrown when JsValue is in incorrect format
+      */
+    def read(value: JsValue) : InstanceState = value match {
       case JsString(s) => s match {
-        case "Running" => InstanceEnums.InstanceState.Running
-        case "Stopped" => InstanceEnums.InstanceState.Stopped
-        case "Failed" => InstanceEnums.InstanceState.Failed
-        case "Paused" => InstanceEnums.InstanceState.Paused
-        case "NotReachable" => InstanceEnums.InstanceState.NotReachable
+        case "Running" => InstanceState.Running
+        case "Stopped" => InstanceState.Stopped
+        case "Failed" => InstanceState.Failed
+        case "Paused" => InstanceState.Paused
+        case "NotReachable" => InstanceState.NotReachable
+        case "Deploying" => InstanceState.Deploying
         case x => throw DeserializationException(s"Unexpected string value $x for instance state.")
       }
-      case y => throw DeserializationException(s"Unexpected type $y while deserializing instance state.")
+      case y => throw DeserializationException(s"Unexpected type $y during deserialization instance state.")
     }
   }
 
-  implicit val instanceFormat : JsonFormat[Instance] = jsonFormat8(Instance)
+  //JSON format for Instances
+  implicit val instanceFormat : JsonFormat[Instance] = jsonFormat10(Instance)
 }
 
+/**
+  * The instance type used for transmitting data about an instance from an to the registry
+  * @param id Id of the instance. This is an Option[Long], as an registering instance will not yet have an id.
+  * @param host Host of the instance.
+  * @param portNumber Port the instance is reachable at.
+  * @param name Name of the instance
+  * @param componentType ComponentType of the instance.
+  * @param dockerId The docker container id of the instance. This is an Option[String], as not all instance have to be docker containers.
+  * @param instanceState State of the instance
+  */
 final case class Instance (
                             id: Option[Long],
                             host: String,
                             portNumber: Long,
                             name: String,
-                            componentType: InstanceEnums.ComponentType,
+                            componentType: ComponentType,
                             dockerId: Option[String],
-                            instanceState: InstanceEnums.State,
-                            labels: List[String]
+                            instanceState: InstanceState,
+                            labels: List[String],
+                            linksTo: List[InstanceLink],
+                            linksFrom: List[InstanceLink]
                           )
-{
-}
 
+/**
+  * Enumerations concerning instances
+  */
 object InstanceEnums {
 
+  //Type to use when working with component types
   type ComponentType = ComponentType.Value
+
+  /**
+    * ComponentType enumeration defining the valid types of delphi components
+    */
   object ComponentType extends Enumeration {
     val Crawler  : Value = Value("Crawler")
     val WebApi : Value = Value("WebApi")
@@ -81,8 +129,14 @@ object InstanceEnums {
     val ElasticSearch : Value = Value("ElasticSearch")
   }
 
-  type State = InstanceState.Value
+  //Type to use when working with instance states
+  type InstanceState = InstanceState.Value
+
+  /**
+    * InstanceState enumeration defining the valid states for instances of delphi components
+    */
   object InstanceState extends Enumeration {
+    val Deploying : Value = Value("Deploying")
     val Running : Value = Value("Running")
     val Stopped : Value = Value("Stopped")
     val Failed : Value = Value("Failed")

--- a/app/utils/instancemanagement/InstanceLink.scala
+++ b/app/utils/instancemanagement/InstanceLink.scala
@@ -1,0 +1,53 @@
+// Copyright (C) 2018 The Delphi Team.
+// See the LICENCE file distributed with this work for additional
+// information regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package utils.instancemanagement
+
+import LinkEnums.LinkState
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
+import spray.json.{DefaultJsonProtocol, DeserializationException, JsString, JsValue, JsonFormat}
+
+trait InstanceLinkJsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
+
+  implicit val linkStateFormat: JsonFormat[LinkState] = new JsonFormat[LinkState] {
+    override def read(value: JsValue): LinkState = value match {
+      case JsString(s) => s match {
+        case "Assigned" => LinkState.Assigned
+        case "Outdated" => LinkState.Outdated
+        case "Failed" => LinkState.Failed
+        case x => throw DeserializationException(s"Unexpected string value $x for LinkState.")
+      }
+      case y => throw DeserializationException(s"Unexpected type $y during deserialization of LinkState")
+    }
+
+    override def write(linkState: LinkState): JsValue = JsString(linkState.toString)
+  }
+
+  implicit val instanceLinkFormat: JsonFormat[InstanceLink] =
+    jsonFormat3(InstanceLink)
+}
+
+
+final case class InstanceLink(idFrom: Long, idTo:Long, linkState: LinkState)
+
+object LinkEnums {
+  type LinkState = LinkState.Value
+
+  object LinkState extends Enumeration {
+    val Assigned: Value =  Value("Assigned")
+    val Failed: Value = Value("Failed")
+    val Outdated: Value = Value("Outdated")
+  }
+}

--- a/app/utils/instancemanagement/InstanceRegistry.scala
+++ b/app/utils/instancemanagement/InstanceRegistry.scala
@@ -31,7 +31,7 @@ import scala.concurrent.duration._
 import scala.util.{Failure, Success, Try}
 import spray.json._
 
-object InstanceRegistry extends JsonSupport with AppLogging
+object InstanceRegistry extends InstanceJsonSupport with AppLogging
 {
 
   implicit val system: ActorSystem = ActorSystem("delphi-webapp")
@@ -265,8 +265,9 @@ object InstanceRegistry extends JsonSupport with AppLogging
   }
 
 
-  private def createInstance(id: Option[Long], controlPort : Int, name : String, dockerId : Option[String], instanceState: InstanceEnums.State) : Instance =
-    Instance(id, InetAddress.getLocalHost.getHostAddress, controlPort, name, ComponentType.WebApp, dockerId, instanceState, List.empty[String])
+  private def createInstance(id: Option[Long], controlPort : Int, name : String, dockerId : Option[String], instanceState: InstanceEnums.InstanceState) : Instance =
+    Instance(id, InetAddress.getLocalHost.getHostAddress, controlPort, name, ComponentType.WebApp, dockerId,
+      instanceState, List.empty[String], List.empty[InstanceLink], List.empty[InstanceLink])
 
 
   object ReportOperationType extends Enumeration {


### PR DESCRIPTION
**Reason for this PR**
The interface of the instance registry has been changed [lately](https://github.com/delphi-hub/delphi-registry/pull/33). The reason for this was to better support the requirements of the Delphi-Management state management. The relevant change is:
- The attributes ```linksTo: List[InstanceLink]``` and ```linksFrom: List[InstanceLink]``` have been added to the Instance class
This PR adapts the WebApp to this change.

**Changes**
- Added file ```InstanceLink.scala``` containing the JSON support
- Added new attributes to Instance
