### PR TITLE
Introduced JWT based authorization for registry communication

### DIFF
--- a/app/authorization/AuthProvider.scala
+++ b/app/authorization/AuthProvider.scala
@@ -1,0 +1,35 @@
+// Copyright (C) 2018 The Delphi Team.
+// See the LICENCE file distributed with this work for additional
+// information regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package authorization
+
+import pdi.jwt.{Jwt, JwtAlgorithm, JwtClaim}
+import utils.CommonHelper
+
+object AuthProvider {
+
+  def generateJwt(validFor: Long = 1, useGenericName: Boolean = false): String = {
+    val claim = JwtClaim()
+      .issuedNow
+      .expiresIn(validFor * 60)
+      .startsNow
+      .+("user_id", if (useGenericName) CommonHelper.configuration.instanceName else s"${CommonHelper.configuration.assignedID.get}")
+      .+("user_type", "Component")
+
+
+    Jwt.encode(claim, CommonHelper.configuration.jwtSecretKey, JwtAlgorithm.HS256)
+  }
+
+}

--- a/app/authorization/AuthProvider.scala
+++ b/app/authorization/AuthProvider.scala
@@ -25,8 +25,8 @@ object AuthProvider {
       .issuedNow
       .expiresIn(validFor * 60)
       .startsNow
-      .+("user_id", if (useGenericName) CommonHelper.configuration.instanceName else s"${CommonHelper.configuration.assignedID.get}")
-      .+("user_type", "Component")
+      . + ("user_id", if (useGenericName) CommonHelper.configuration.instanceName else s"${CommonHelper.configuration.assignedID.get}")
+      . + ("user_type", "Component")
 
 
     Jwt.encode(claim, CommonHelper.configuration.jwtSecretKey, JwtAlgorithm.HS256)

--- a/app/utils/Configuration.scala
+++ b/app/utils/Configuration.scala
@@ -65,6 +65,8 @@ class Configuration(val bindPort: Int = ConfigFactory.load().getInt("app.portWeb
     case None => defaultWebApiPort
   }
 
+  val jwtSecretKey: String  = sys.env.getOrElse("DELPHI_JWT_SECRET","changeme")
+
   lazy val fallbackWebApiHost : String = sys.env.get("DELPHI_WEBAPI_URI") match {
     case Some(hostString) =>
       if(hostString.count(c => c == ':') == 2){

--- a/build.sbt
+++ b/build.sbt
@@ -22,6 +22,8 @@ resolvers += Resolver.sonatypeRepo("snapshots")
 libraryDependencies += guice
 libraryDependencies += "org.scalatestplus.play" %% "scalatestplus-play" % "3.1.2" % Test
 
+libraryDependencies += "com.pauldijou" %% "jwt-core" % "1.0.0"
+
 // Akka dependencies
 libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-http-core" % "10.0.11",


### PR DESCRIPTION
**Reason for this PR**
The instance registry will require authentication based on JSON Web Tokens (JWTs) soon (as described [here](https://github.com/delphi-hub/delphi-registry/issues/64)). The components of the Delphi system have to be able to generate valid JWTs based on a secret that is either passed in an environment variable or in the configuration file. They have to add the encoded token in the ```Authorization``` header of every HTTP request issued to the registry. For more information see the respective [issue](https://github.com/delphi-hub/delphi-registry/issues/35).

**Changes in this PR**
- The WebApp is now able to generate valid JWTs based on a secret specified in an environment variable (using HS256 signature algorithm)
- The WebApp sends an encoded valid JWT with every request issued to the registry
