### PR TITLE
Integrated support for Traefik reverse-proxy setup

### DIFF
--- a/app/controllers/HomeController.scala
+++ b/app/controllers/HomeController.scala
@@ -15,6 +15,7 @@
 // limitations under the License.
 package controllers
 
+import akka.http.scaladsl.model.HttpMethods
 import javax.inject._
 import play.api.Configuration
 import play.api.mvc._
@@ -48,11 +49,11 @@ class HomeController @Inject()(configuration: Configuration, cc: ControllerCompo
     */
   def query(query : String) : Action[AnyContent] = Action.async {
     implicit request => {
-      val server = CommonHelper.addHttpProtocolIfNotExist(CommonHelper.configuration.webApiUri)
-      val getRequest = BlockingHttpClient.executeGet("/search/" + query, server)
-      getRequest match {
+      val request = CommonHelper.createWebApiRequest("/search/" + query, HttpMethods.GET)
+      val result = BlockingHttpClient.executeRequest(request)
+      result match {
         case Success(response) => Future.successful(Ok(views.html.index(response, query, false)))
-        case Failure(_) => Future.successful(Ok(views.html.index("ERROR: Failed to reach server at " + server, query, true)))
+        case Failure(_) => Future.successful(Ok(views.html.index("ERROR: Failed to reach server at " + request.uri, query, true)))
       }
     }
   }

--- a/app/utils/BlockingHttpClient.scala
+++ b/app/utils/BlockingHttpClient.scala
@@ -33,13 +33,13 @@ import MediaTypes._
   */
 object BlockingHttpClient {
 
-  def doGet(uri : Uri) : Try[String] = {
+  def executeRequest(request: HttpRequest): Try[String] = {
     implicit val system: ActorSystem = ActorSystem()
     implicit val executionContext: ExecutionContext = system.dispatcher
     implicit val materializer: ActorMaterializer = ActorMaterializer(ActorMaterializerSettings(system))
 
     try {
-      val req: Future[HttpResponse] = Http(system).singleRequest(HttpRequest(method = HttpMethods.GET, uri = uri))
+      val req: Future[HttpResponse] = Http(system).singleRequest(request)
       Await.result(req, Duration.Inf)
 
       val f = req.value.get.get.entity.dataBytes.runFold(ByteString(""))(_ ++ _)
@@ -52,8 +52,9 @@ object BlockingHttpClient {
       system.terminate()
       Await.result(system.whenTerminated, Duration.Inf)
     }
-
   }
+
+  def doGet(uri : Uri) : Try[String] = executeRequest(HttpRequest(method = HttpMethods.GET, uri = uri))
 
   // data parameter will be """{"name":"Hello"}"""
   def doPost(uri: Uri, data: String) : Try[String] = {

--- a/app/utils/CommonHelper.scala
+++ b/app/utils/CommonHelper.scala
@@ -15,8 +15,9 @@
 // limitations under the License.
 package utils
 
-import akka.http.scaladsl.model.headers.RawHeader
+import akka.http.scaladsl.model.headers.{Host, RawHeader}
 import akka.http.scaladsl.model.{HttpMethod, HttpRequest}
+
 import scala.collection.immutable.Seq
 
 object CommonHelper {
@@ -40,7 +41,7 @@ object CommonHelper {
         val traefikHost = configuration.webApiInstance.traefikConfiguration.get.proxyUri
         val apiHostName = configuration.webApiInstance.traefikConfiguration.get.hostName
         //We are outside docker and target is inside -> Need to call traefik
-        HttpRequest(method, addHttpProtocolIfNotExist(traefikHost) + path, Seq(RawHeader("Host", apiHostName)))
+        HttpRequest(method, addHttpProtocolIfNotExist(traefikHost) + path, Seq(Host(apiHostName)))
       } else {
         HttpRequest(method, addHttpProtocolIfNotExist(configuration.webApiUri) + path)
       }

--- a/app/utils/CommonHelper.scala
+++ b/app/utils/CommonHelper.scala
@@ -15,6 +15,10 @@
 // limitations under the License.
 package utils
 
+import akka.http.scaladsl.model.headers.RawHeader
+import akka.http.scaladsl.model.{HttpMethod, HttpRequest}
+import scala.collection.immutable.Seq
+
 object CommonHelper {
 
   val configuration: Configuration = new Configuration()
@@ -27,4 +31,20 @@ object CommonHelper {
         url
       }
     }
+
+    def createWebApiRequest(path: String, method: HttpMethod): HttpRequest = {
+      val insideContainer = sys.env.get("INSTANCE_ID").isDefined
+      val apiInDocker = configuration.webApiInstance.traefikConfiguration.isDefined
+
+      if(apiInDocker && !insideContainer) {
+        val traefikHost = configuration.webApiInstance.traefikConfiguration.get.proxyUri
+        val apiHostName = configuration.webApiInstance.traefikConfiguration.get.hostName
+        //We are outside docker and target is inside -> Need to call traefik
+        HttpRequest(method, addHttpProtocolIfNotExist(traefikHost) + path, Seq(RawHeader("Host", apiHostName)))
+      } else {
+        HttpRequest(method, addHttpProtocolIfNotExist(configuration.webApiUri) + path)
+      }
+
+    }
+
 }

--- a/app/utils/instancemanagement/Instance.scala
+++ b/app/utils/instancemanagement/Instance.scala
@@ -83,8 +83,11 @@ trait InstanceJsonSupport extends SprayJsonSupport with DefaultJsonProtocol with
     }
   }
 
+  //JSON format for traefik config information
+  implicit val traefikConfigFormat : JsonFormat[TraefikConfiguration] = jsonFormat2(TraefikConfiguration)
+
   //JSON format for Instances
-  implicit val instanceFormat : JsonFormat[Instance] = jsonFormat10(Instance)
+  implicit val instanceFormat : JsonFormat[Instance] = jsonFormat11(Instance)
 }
 
 /**
@@ -107,8 +110,17 @@ final case class Instance (
                             instanceState: InstanceState,
                             labels: List[String],
                             linksTo: List[InstanceLink],
-                            linksFrom: List[InstanceLink]
+                            linksFrom: List[InstanceLink],
+                            traefikConfiguration: Option[TraefikConfiguration] = None
                           )
+
+
+/**
+* The connection information regarding the Traefik reverse-proxy setup
+* @param hostName DNS host name that has been assigned to this instance
+* @param proxyUri URI that the Traefik reverse-proxy is running at
+*/
+final case class TraefikConfiguration (hostName: String, proxyUri: String)
 
 /**
   * Enumerations concerning instances

--- a/app/utils/instancemanagement/InstanceRegistry.scala
+++ b/app/utils/instancemanagement/InstanceRegistry.scala
@@ -188,7 +188,7 @@ object InstanceRegistry extends InstanceJsonSupport with AppLogging
       } else {
         val idToPost = configuration.webApiInstance.id.getOrElse(-1L)
 
-        val MatchingData = JsObject("MatchingSuccessful" -> JsBoolean(isWebApiReachable),
+        val matchingData = JsObject("MatchingSuccessful" -> JsBoolean(isWebApiReachable),
           "SenderId" -> JsNumber(configuration.assignedID.getOrElse(-1L)))
 
         val request = HttpRequest(
@@ -197,7 +197,7 @@ object InstanceRegistry extends InstanceJsonSupport with AppLogging
 
         Await.result(Http(system).singleRequest(request
           .withHeaders(RawHeader("Authorization",s"Bearer ${AuthProvider.generateJwt()}"))
-          .withEntity(ContentTypes.`application/json`, ByteString(MatchingData.toJson.toString))) map {response =>
+          .withEntity(ContentTypes.`application/json`, ByteString(matchingData.toJson.toString))) map {response =>
 
           if(response.status == StatusCodes.OK){
             log.info("Successfully posted matching result to Instance Registry.")

--- a/app/utils/instancemanagement/InstanceRegistry.scala
+++ b/app/utils/instancemanagement/InstanceRegistry.scala
@@ -213,7 +213,8 @@ object InstanceRegistry extends InstanceJsonSupport with AppLogging
   }
 
   def getWebApiVersion(configuration: Configuration) : Try[ResponseEntity]  = {
-    val request = HttpRequest(method = HttpMethods.GET, CommonHelper.addHttpProtocolIfNotExist(CommonHelper.configuration.webApiUri) + "/version")
+
+    val request = CommonHelper.createWebApiRequest("/version", HttpMethods.GET)
 
     Await.result(Http(system).singleRequest(request) map {response =>
       if(response.status == StatusCodes.OK){


### PR DESCRIPTION
**Reason for this PR**
We [recently](https://github.com/delphi-hub/delphi-registry/pull/99) added support for the reverse-proxy Traefik to the registry. The setup with Traefik allows users and applications to connect to instances deployed inside a docker container. Instead of directly connecting to the requested instance, the users / applications can connect to the Traefik-Host, and specify the additional header ```Host: <unique-host-string>```, which will relay them to their actual target.

The WebApp has to decide whether or not it can connect using IP and Port (when both instances are inside the Docker network, or when the WebApi is outside Docker) or using Traefik (when WebApi is inside Docker network and WebApp is not).

**Changes in this PR**
- Adapted instance model according to changes in registry. There now is an optional field ```TraefikConfig``` which contains the unique host string assigned to the instance by Traefik.
- Implemented logic that decides whether or not is has to use Traefik when calling the WebApi, and creates a corresponding HttpRequest
- Fixed a codestyle issue i missed in the last PR #26 (uppercase variable name)